### PR TITLE
63 subscriptions of other users

### DIFF
--- a/price_monitor/api/views/ProductCreateRetrieveUpdateDestroyAPIView.py
+++ b/price_monitor/api/views/ProductCreateRetrieveUpdateDestroyAPIView.py
@@ -1,10 +1,11 @@
+from .mixins.ProductFilteringMixin import ProductFilteringMixin
 from ..serializers.ProductSerializer import ProductSerializer
 from ...models.Product import Product
 
 from rest_framework import generics, mixins, permissions
 
 
-class ProductCreateRetrieveUpdateDestroyAPIView(mixins.CreateModelMixin, generics.RetrieveUpdateDestroyAPIView):
+class ProductCreateRetrieveUpdateDestroyAPIView(ProductFilteringMixin, mixins.CreateModelMixin, generics.RetrieveUpdateDestroyAPIView):
     """
     Returns single instance of Product, if user is authenticated
     """

--- a/price_monitor/api/views/ProductListView.py
+++ b/price_monitor/api/views/ProductListView.py
@@ -1,10 +1,11 @@
+from rest_framework import generics, permissions
+
+from .mixins.ProductFilteringMixin import ProductFilteringMixin
 from ..serializers.ProductSerializer import ProductSerializer
 from ...models.Product import Product
 
-from rest_framework import generics, permissions
 
-
-class ProductListView(generics.ListAPIView):
+class ProductListView(ProductFilteringMixin, generics.ListAPIView):
     """
     Returns list of Products and provides endpoint to create Products,
     if user is authenticated
@@ -12,19 +13,8 @@ class ProductListView(generics.ListAPIView):
     model = Product
     serializer_class = ProductSerializer
     allow_empty = True
+    queryset = Product.objects.all()
     permission_classes = [
         # only return the list if user is authenticated
         permissions.IsAuthenticated
     ]
-
-    def get_queryset(self):
-        """
-        Filters queryset by the authenticated user
-        :returns: filtered Product objects
-        :rtype:   QuerySet
-        """
-        # distinct is needed to prevent multiple instances of product in resultset if multiple subscriptions are present
-        return self.model.objects\
-            .select_related('highest_price', 'lowest_price', 'current_price')\
-            .prefetch_related('subscription_set__email_notification')\
-            .filter(subscription__owner=self.request.user).distinct()

--- a/price_monitor/api/views/mixins/ProductFilteringMixin.py
+++ b/price_monitor/api/views/mixins/ProductFilteringMixin.py
@@ -1,0 +1,24 @@
+from django.db.models.query import Prefetch
+
+from ....models.Subscription import Subscription
+
+
+class ProductFilteringMixin(object):
+
+    def filter_queryset(self, queryset):
+        """
+        Filters queryset by the authenticated user
+        :returns: filtered Product objects
+        :rtype:   QuerySet
+        """
+        queryset = super(ProductFilteringMixin, self).filter_queryset(queryset)
+        return queryset\
+            .select_related('highest_price', 'lowest_price', 'current_price')\
+            .prefetch_related(
+                Prefetch(
+                    'subscription_set',
+                    queryset=Subscription.objects.filter(
+                        owner=self.request.user
+                    ).select_related('email_notification').distinct()
+                )
+            ).filter(subscription__owner=self.request.user).distinct()

--- a/price_monitor/templates/price_monitor/angular_index_view.html
+++ b/price_monitor/templates/price_monitor/angular_index_view.html
@@ -61,7 +61,7 @@
                     'price': '{% url "api_product_list" %}:asin/prices/',
                     'product': '{% url "api_product_list" %}:asin/',
                     'subscription': '{% url "api_subscription_list" %}:public_id/{#{% url "api_subscription_retrieve" public_id=":public_id" %}#}',
-                    'sparkline': '{% url "api_product_list" %}:asin/prices/?show_legend=false&show_dots=false&margin=4&spacing=0&height=40&width=400&y_labels_major_count=2&show_minor_y_labels=false&no_data_font_size=10',
+                    'sparkline': '{% url "api_product_list" %}:asin/prices/?show_legend=false&show_dots=false&margin=4&spacing=0&height=40&width=400&show_x_labels=false&y_labels_major_count=2&show_minor_y_labels=false&no_data_font_size=10',
                     'chart': {
                         'default': '{% url "api_product_list" %}:asin/prices/?show_legend=false&show_x_values=false&margin=4&spacing=0&y_labels_major_count=5&show_minor_y_labels=true&no_data_font_size=10&width=400&height=200',
                         'small': '{% url "api_product_list" %}:asin/prices/?show_legend=false&margin=4&spacing=4&y_labels_major_count=5&show_minor_y_labels=true&no_data_font_size=10&width=600&height=200',


### PR DESCRIPTION
This fixes the retrieval of subscriptions per product, so only the subscriptions of the current user are shown while not killing performance on list or single product api end points.