### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/price_monitor/__init__.py
+++ b/price_monitor/__init__.py
@@ -12,11 +12,11 @@ __version_info__ = {
 
 def get_version(short=False):
     assert __version_info__['releaselevel'] in ('alpha', 'beta', 'final')
-    version = ["%(major)i.%(minor)i" % __version_info__, ]
+    version = ["{major:d}.{minor:d}".format(**__version_info__), ]
     if __version_info__['micro']:
-        version.append(".%(micro)i" % __version_info__)
+        version.append(".{micro:d}".format(**__version_info__))
     if __version_info__['releaselevel'] != 'final' and not short:
-        version.append('%s%i' % (__version_info__['releaselevel'][0], __version_info__['serial']))
+        version.append('{0!s}{1:d}'.format(__version_info__['releaselevel'][0], __version_info__['serial']))
     return ''.join(version)
 
 __version__ = get_version()

--- a/price_monitor/management/commands/price_monitor_batch_create_products.py
+++ b/price_monitor/management/commands/price_monitor_batch_create_products.py
@@ -29,4 +29,4 @@ class Command(BaseCommand):
         for asin in asins:
             Product.objects.create(asin=asin)
 
-        print('created %d products' % len(asins))
+        print('created {0:d} products'.format(len(asins)))

--- a/price_monitor/models/EmailNotification.py
+++ b/price_monitor/models/EmailNotification.py
@@ -21,9 +21,9 @@ class EmailNotification(PublicIDMixin, models.Model):
         :rtype: unicode
         """
         return text_type(
-            ' %(email)s' % {
+            ' {email!s}'.format(**{
                 'email': self.email,
-            }
+            })
         )
 
     class Meta:

--- a/price_monitor/models/Price.py
+++ b/price_monitor/models/Price.py
@@ -19,11 +19,11 @@ class Price(models.Model):
         :return: the unicode representation
         :rtype: unicode
         """
-        return '%(value)s %(currency)s on %(date_seen)s' % dict(
-            value='%0.2f' % self.value if self.value else 'No price',
+        return '{value!s} {currency!s} on {date_seen!s}'.format(**dict(
+            value='{0:0.2f}'.format(self.value) if self.value else 'No price',
             currency=self.currency if self.currency else '',
             date_seen=self.date_seen
-        )
+        ))
 
     class Meta:
         app_label = 'price_monitor'

--- a/price_monitor/models/Product.py
+++ b/price_monitor/models/Product.py
@@ -101,7 +101,7 @@ class Product(models.Model):
         :return: the cache key
         :rtype:  str
         """
-        return 'graph-%s-%s' % (self.asin, self.date_last_synced.isoformat() if self.date_last_synced is not None else '')
+        return 'graph-{0!s}-{1!s}'.format(self.asin, self.date_last_synced.isoformat() if self.date_last_synced is not None else '')
 
     def get_title(self):
         """

--- a/price_monitor/models/Subscription.py
+++ b/price_monitor/models/Subscription.py
@@ -29,10 +29,10 @@ class Subscription(PublicIDMixin, models.Model):
         :return: the unicode representation
         :rtype: unicode
         """
-        return 'Subscription of "%(product)s" for %(user)s' % {
+        return 'Subscription of "{product!s}" for {user!s}'.format(**{
             'product': self.product.title,
             'user': self.owner.username,
-        }
+        })
 
     class Meta:
         app_label = 'price_monitor'

--- a/price_monitor/product_advertising_api/api.py
+++ b/price_monitor/product_advertising_api/api.py
@@ -77,11 +77,11 @@ class ProductAdvertisingAPI(object):
         ex = error['exception']
 
         logger.error(
-            'Error was thrown upon requesting URL %(api_url)s (Cache-URL: %(cache_url)s: %(exception)r' % {
+            'Error was thrown upon requesting URL {api_url!s} (Cache-URL: {cache_url!s}: {exception!r}'.format(**{
                 'api_url': error['api_url'],
                 'cache_url': error['cache_url'],
                 'exception': ex,
-            }
+            })
         )
 
         # try reconnect

--- a/price_monitor/product_advertising_api/tasks.py
+++ b/price_monitor/product_advertising_api/tasks.py
@@ -280,13 +280,13 @@ class NotifySubscriberTask(Task):
             logger.error('Subscription with PK %d could not be found.', subscription_pk)
             return False
 
-        logger.info('Trying to send notification email to %(email)s...' % {'email': subscription.email_notification.email})
+        logger.info('Trying to send notification email to {email!s}...'.format(**{'email': subscription.email_notification.email}))
         try:
             send_mail(product, subscription, price)
         except SMTPServerDisconnected:
             logger.exception('SMTP server was disconnected.')
         else:
-            logger.info('Notification email to %(email)s was sent!' % {'email': subscription.email_notification.email})
+            logger.info('Notification email to {email!s} was sent!'.format(**{'email': subscription.email_notification.email}))
             subscription.date_last_notification = timezone.now()
             subscription.save()
             return True

--- a/price_monitor/utils.py
+++ b/price_monitor/utils.py
@@ -57,7 +57,7 @@ def parse_audience_rating(rating):
         if rating == 'Freigegeben ohne Altersbeschränkung':
             return 0
 
-        logger.error('Unable to parse audience rating value "%(audience_rating)s"' % {'audience_rating': rating})
+        logger.error('Unable to parse audience rating value "{audience_rating!s}"'.format(**{'audience_rating': rating}))
         return rating
 
     return int(result.groups()[0])


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:ponyriders:django-amazon-price-monitor?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:ponyriders:django-amazon-price-monitor?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)